### PR TITLE
Add support for dynamic api_key for ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,10 @@ sudo logstash-plugin install path/logstash-output-logdna-0.1.7.gem
 
 
 ## Configuration Example.
-Note that `api_key` and `hostname` are required fields.  The rest optional.  For event data like `app`, these are the default values to use.   
+Note that `api_key` and `hostname` are required fields.  The rest optional.  For event data like `app`, these are the default values to use.
+
+In case `api_key` is <b>dynamic</b> to support for multiple customer. Add dynamic `api_key` to `[@metadata][logdna][api_key]`. Check `test.logstash-output-logdna.conf` for more information.
+
 If your data is already formatted to JSON, change the "format" from `plain/text` to `application/json`
 ```
 output{

--- a/lib/logstash/outputs/logdna.rb
+++ b/lib/logstash/outputs/logdna.rb
@@ -122,7 +122,8 @@ class LogStash::Outputs::LogDNA < LogStash::Outputs::Base
   end
 
   def genLogDNAUrl(event)
-    tmp_url = "#{@base_url}?apikey=#{@api_key}"
+    ingestion_key = event.get('[@metadata][logdna][api_key]') ? event.get('[@metadata][logdna][api_key]') : @api_key
+    tmp_url = "#{@base_url}?apikey=#{ingestion_key}"
 
     # Note that we will try and grab these from the event.
     #    if they appear as first level attributes, they will

--- a/test.logstash-output-logdna.conf
+++ b/test.logstash-output-logdna.conf
@@ -39,6 +39,11 @@ input {
     add_field => {
       "_env" => "_env_logdna_test"
     }
+
+    # If setting dynamic api_key in case for different customer
+    # add_field => {
+    #   "[@metadata][logdna][api_key]" => 'YOUR_DYNAMIC_API_KEY'
+    # }
   }
 }
 
@@ -46,6 +51,7 @@ output {
   logdna {
     base_url => "https://logs.logdna.com/logs/ingest"
     api_key => "YOUR_API_KEY"
+    # api_key => "%{[@metadata][logdna][api_key]}" # Comment above `api_key` and un-comment this line for dynamic api_key
     hostname => "TESTING_HTTP"
     format => "plain/text"
     app => "logstash_testing_app"


### PR DESCRIPTION
Problem Description
------
For the scenario, wherein multiple customers have their respective `api_key` used for ingestion. In this case, we were not able to dynamically set the `api_key` property. 

Proposed Solution:
------
Modified code to include `[@metadata][logdna][api_key]` to handle dynamic `api_key`. Using `@metadata` the `api_key` is not included in the events sent to LogDNA.

Verified with existing `api_key` hardcoded and using the dynamic value set through `[@metadata][logdna][api_key]`

**Configuration used for testing ingestion**

```
logdna {
            base_url => "https://logs.logdna.com/logs/ingest"
            api_key => "%{[@metadata][logdna][api_key]}"
            app => "SUJ_APP_NAME"
            hostname => "%{hostname}"
            env => "dev"
            ip => "%{ip}"
            mac => "%{mac}"
            tags => "TAG1,TAG2"
            format => "plain/text"
            automatic_retries => 3
            retry_failed => true
            level => "INFO"
        }
```

**Screenshot of log ingestion**

- `test message` with default `api_key` hardcoded
- `logdna plugin message` with dynamically set `api_key`

![image](https://user-images.githubusercontent.com/6076638/136141516-3d8082f1-52eb-49c3-adcc-625bf9e99f96.png)
